### PR TITLE
Fix deploy by removing absolute links

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -45,3 +45,4 @@ jobs:
           SSH: true
           BRANCH: gh-pages
           FOLDER: __sapper__/export${{ env.BASE_PATH }}
+          CLEAN: true

--- a/src/components/MobileMenu.svelte
+++ b/src/components/MobileMenu.svelte
@@ -124,7 +124,7 @@
       <a>Documentation</a>
     </li>
     <li>
-      <a href="/pricing">Pricing</a>
+      <a href="pricing">Pricing</a>
     </li>
     <li>
       <a>Open Sources</a>

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -117,7 +117,7 @@
   <div class="container-fluid">
     <div class="row">
       <div class="logo-wrapper col-6 col-sm-6 col-md-3">
-        <a href="/">
+        <a href="">
           <img src="header-logo.png" alt="Skygear Auth Logo" />
         </a>
       </div>
@@ -134,7 +134,7 @@
               <a>Documentation</a>
             </li>
             <li>
-              <a href="/pricing">Pricing</a>
+              <a href="pricing">Pricing</a>
             </li>
             <li>
               <a>Open Sources</a>


### PR DESCRIPTION
Addresses #35 

Navigation links on the staging site were broken because they were absolute links instead of relative to the base path. I will fix this issue in my favicon PR as well.