### PR TITLE
Fix height growth of hero header img

### DIFF
--- a/src/components/HeroHeader.svelte
+++ b/src/components/HeroHeader.svelte
@@ -14,11 +14,7 @@
 
   .hero-img {
     max-width: 100%;
-  }
-
-  .hero-img-wrapper {
-    display: flex;
-    justify-content: flex-end;
+    float: right;
   }
 
   .tagline h1 {
@@ -93,7 +89,7 @@
         </p>
         <ContactForm />
       </div>
-      <div class="hero-img-wrapper col-12 col-md-7">
+      <div class="col-12 col-md-7">
         <img class="hero-img" src="img/hero-header-img.png" alt="Hero Header" />
       </div>
     </div>


### PR DESCRIPTION
Addresses #44 

This issue was taking place because the hero header image was nested inside a flex container causing the height to expand. Inconsistencies in flexbox implementation made this problem less visible on Chrome.

One way to resolve this issue is to set the `flex-grow` attribute of the img to 0 but I've decided to replace the flex-container with a `float` attribute which achieves the same purpose as what I initially used flexbox for (that is, to float the header image to the right). 