### PR TITLE
Fix mobile breakpoint boundaries

### DIFF
--- a/src/components/CallToAction.svelte
+++ b/src/components/CallToAction.svelte
@@ -35,7 +35,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .cta {
       padding-top: 30px;
       padding-bottom: 25px;

--- a/src/components/CodeEditor.svelte
+++ b/src/components/CodeEditor.svelte
@@ -143,7 +143,7 @@
     opacity: 1;
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .editor__header__copybtn-wrapper {
       display: none;
     }

--- a/src/components/CodeSample.svelte
+++ b/src/components/CodeSample.svelte
@@ -61,7 +61,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .code-sample {
       padding-bottom: 60px;
     }

--- a/src/components/ContactForm.svelte
+++ b/src/components/ContactForm.svelte
@@ -40,7 +40,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .contact-wrapper {
       flex-direction: column;
     }

--- a/src/components/DevicesDemo.svelte
+++ b/src/components/DevicesDemo.svelte
@@ -25,7 +25,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .devices-demo__img-wrapper {
       padding-left: 43px;
       padding-right: 65px;

--- a/src/components/Features.svelte
+++ b/src/components/Features.svelte
@@ -99,7 +99,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .features-section {
       padding-top: 60px;
     }

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -52,7 +52,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     img.footer-logo {
       width: 115px;
     }

--- a/src/components/HeroHeader.svelte
+++ b/src/components/HeroHeader.svelte
@@ -53,7 +53,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .hero-section {
       padding: 85px 0 40px 0;
     }

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -149,7 +149,7 @@
     }
   }
 
-  @media screen and (min-width: 768px) and (max-width: 992px) {
+  @media screen and (min-width: 768px) and (max-width: 991px) {
     .container-fluid {
       padding-right: 45px;
       padding-left: 45px;
@@ -166,7 +166,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .container-fluid {
       padding-right: 10px;
       padding-left: 10px;

--- a/src/components/PricingFAQ.svelte
+++ b/src/components/PricingFAQ.svelte
@@ -68,7 +68,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .container-fluid {
       padding-left: 18px;
       padding-right: 18px;

--- a/src/components/PricingHeader.svelte
+++ b/src/components/PricingHeader.svelte
@@ -21,7 +21,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .pricing__header__title {
       padding-left: 18px;
       padding-right: 18px;

--- a/src/components/PricingTable.svelte
+++ b/src/components/PricingTable.svelte
@@ -65,7 +65,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .pricing-table {
       padding-top: 30px;
       padding-bottom: 30px;

--- a/src/components/Resources.svelte
+++ b/src/components/Resources.svelte
@@ -55,7 +55,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .resources {
       padding-top: 30px;
       padding-bottom: 30px;

--- a/src/components/TrustedBy.svelte
+++ b/src/components/TrustedBy.svelte
@@ -48,7 +48,7 @@
     }
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 767px) {
     .trustedby {
       padding-top: 25px;
       padding-bottom: 80px;


### PR DESCRIPTION
Addresses #48 

Breakpoint to medium-sized container in bootstrap is set to `768px`. The same breakpoint value is used in our CSS but setting the media query `max-width` and `min-width` equal to each other causes the `min-width` media query to be overidden incorrectly.

Solution: reduce max-width breakpoint by 1px.