### PR TITLE
Setup deploy-prod workflow and update README

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,14 +11,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - name: Install dependencies
-        run: npm ci
-      - name: Format code
-        run: npm run check-format
-      - name: Lint svelte files
-        run: npm run lint
-      - name: Generate production build
-        run: npm run export
+      - name: CI test
+        run: make test
   deploy-master:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: 12.x
       - name: CI test
-        run: make test
+        run: make ci-test
   deploy-master:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: test
@@ -40,3 +40,22 @@ jobs:
           BRANCH: gh-pages
           FOLDER: __sapper__/export${{ env.BASE_PATH }}
           CLEAN: true
+  deploy-prod:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+    needs: test
+    env:
+      BASE_PATH: /
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+      CDN_DISTRIBUTION_ID: ${{ secrets.CDN_DISTRIBUTION_ID }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: CI deploy-prod
+        run: make ci-deploy-prod

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,7 +47,7 @@ jobs:
       BASE_PATH: /
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
       CDN_DISTRIBUTION_ID: ${{ secrets.CDN_DISTRIBUTION_ID }}
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .POSIX:
-SHELL = /bin/sh
-BASE_PATH = "/"
+SHELL=/bin/sh
+BASE_PATH="/"
 
 .PHONY: ci-test
 ci-test: 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.POSIX:
+
+.PHONY: test
+test: 
+	@echo "Install dependencies" 
+	npm ci
+	@echo "Check code formatting"
+	npm run check-format
+	@echo "Lint code"
+	npm run lint
+	@echo "Generate production build"
+	npm run export

--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,10 @@ ci-test:
 ci-deploy-prod:
 	@echo "Generate production build"
 	npm run export -- --basepath=$(BASE_PATH)
-	if ! [ -x "$$(command -v aws)" ]; then\
-		@echo "Install AWS CLI";\
-		curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "$(HOME)/awscliv2.zip";\
-		unzip $(HOME)/awscliv2.zip -d $(HOME);\
-		sudo $(HOME)/aws/install;\
+	@if ! [ -x "$$(command -v aws)" ]; then\
+		echo "Please install AWS CLI";\
+		exit 1;\
 	fi
-	@echo "Configure AWS Credentials"
-	aws configure set aws_access_key_id $(AWS_ACCESS_KEY_ID)
-	aws configure set aws_secret_access_key $(AWS_SECRET_ACCESS_KEY)
-	aws configure set region $(AWS_REGION)
 	@echo "Push build to S3 bucket"
 	aws s3 sync __sapper__/export$(BASE_PATH) s3://$(S3_BUCKET_NAME) --delete
 	@echo "Invalidate Cloudfront"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .POSIX:
+SHELL = /bin/sh
+BASE_PATH = "/"
 
-.PHONY: test
-test: 
+.PHONY: ci-test
+ci-test: 
 	@echo "Install dependencies" 
 	npm ci
 	@echo "Check code formatting"
@@ -10,3 +12,22 @@ test:
 	npm run lint
 	@echo "Generate production build"
 	npm run export
+
+.PHONY: ci-deploy-prod
+ci-deploy-prod:
+	@echo "Generate production build"
+	npm run export -- --basepath=$(BASE_PATH)
+	if ! [ -x "$$(command -v aws)" ]; then\
+		@echo "Install AWS CLI";\
+		curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "$(HOME)/awscliv2.zip";\
+		unzip $(HOME)/awscliv2.zip -d $(HOME);\
+		sudo $(HOME)/aws/install;\
+	fi
+	@echo "Configure AWS Credentials"
+	aws configure set aws_access_key_id $(AWS_ACCESS_KEY_ID)
+	aws configure set aws_secret_access_key $(AWS_SECRET_ACCESS_KEY)
+	aws configure set region $(AWS_REGION)
+	@echo "Push build to S3 bucket"
+	aws s3 sync __sapper__/export$(BASE_PATH) s3://$(S3_BUCKET_NAME) --delete
+	@echo "Invalidate Cloudfront"
+	aws cloudfront create-invalidation --distribution-id $(CDN_DISTRIBUTION_ID) --paths "/*"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# auth-landing ![CI Status](https://github.com/SkygearIO/auth-landing/workflows/auth-landing%20CI/badge.svg?branch=master&event=push)
+# auth-landing ![CI Status](https://github.com/authgear/auth-landing/workflows/auth-landing%20CI/badge.svg?branch=master&event=push)
 
 Landing page for Authgear. This repo is based off svelte's [sappler boilerplate](https://github.com/sveltejs/sapper-template/tree/rollup) so for more information look there.
 
-Staging site can be found here: https://skygeario.github.io/auth-landing/
+Staging site can be found here: https://authgear.github.io/auth-landing/
 
 # Setup
 
 ```
-git clone https://github.com/SkygearIO/auth-landing
+git clone https://github.com/authgear/auth-landing
 cd auth-landing
 npm install
 ```


### PR DESCRIPTION
Addresses #51 and #70 

- Creates Makefile targets for `test` and `deploy-prod` CI/CD jobs
- `deploy-prod` job triggers on push to `production` branch
- Will need to setup the following repo secrets for production deploy:
    - AWS_ACCESS_KEY_ID
    - AWS_SECRET_ACCESS_KEY
    - AWS_REGION
    - S3_BUCKET_NAME
    - CDN_DISTRIBUTION_ID

